### PR TITLE
Add collection of QSS theme files

### DIFF
--- a/app/styles/classic_bw.qss
+++ b/app/styles/classic_bw.qss
@@ -1,0 +1,30 @@
+/* Classic black and white theme */
+QDialog {
+    background-color: #ffffff;
+    color: #000000;
+    font-family: "Times New Roman", serif;
+    font-size: 14px;
+}
+
+QPushButton {
+    background-color: #ffffff;
+    color: #000000;
+    border: 1px solid #000000;
+    border-radius: 0px;
+    padding: 6px 12px;
+}
+
+QPushButton:hover {
+    background-color: #e6e6e6;
+}
+
+QLineEdit {
+    background-color: #ffffff;
+    color: #000000;
+    border: 1px solid #000000;
+    padding: 4px;
+}
+
+QLabel {
+    color: #000000;
+}

--- a/app/styles/dark_green.qss
+++ b/app/styles/dark_green.qss
@@ -1,0 +1,30 @@
+/* Dark green theme */
+QDialog {
+    background-color: #0a0a0a;
+    color: #00ff00;
+    font-family: "Consolas", "Monaco", monospace;
+    font-size: 14px;
+}
+
+QPushButton {
+    background-color: #1a1a1a;
+    color: #00ff00;
+    border: 1px solid #00cc00;
+    border-radius: 4px;
+    padding: 6px 12px;
+}
+
+QPushButton:hover {
+    background-color: #2a2a2a;
+}
+
+QLineEdit {
+    background-color: #1a1a1a;
+    color: #00ff00;
+    border: 1px solid #00cc00;
+    padding: 4px;
+}
+
+QLabel {
+    color: #00ff00;
+}

--- a/app/styles/forest_dark.qss
+++ b/app/styles/forest_dark.qss
@@ -1,0 +1,30 @@
+/* Forest dark theme */
+QDialog {
+    background-color: #0b1e13;
+    color: #a3d9a5;
+    font-family: "Georgia", serif;
+    font-size: 14px;
+}
+
+QPushButton {
+    background-color: #1f3d2b;
+    color: #a3d9a5;
+    border: 1px solid #4c9a2a;
+    border-radius: 4px;
+    padding: 6px 12px;
+}
+
+QPushButton:hover {
+    background-color: #295235;
+}
+
+QLineEdit {
+    background-color: #1f3d2b;
+    color: #a3d9a5;
+    border: 1px solid #4c9a2a;
+    padding: 4px;
+}
+
+QLabel {
+    color: #a3d9a5;
+}

--- a/app/styles/light_blue.qss
+++ b/app/styles/light_blue.qss
@@ -1,0 +1,30 @@
+/* Light blue theme */
+QDialog {
+    background-color: #f0f8ff;
+    color: #003366;
+    font-family: "Arial", sans-serif;
+    font-size: 14px;
+}
+
+QPushButton {
+    background-color: #e0f0ff;
+    color: #003366;
+    border: 1px solid #6699cc;
+    border-radius: 4px;
+    padding: 6px 12px;
+}
+
+QPushButton:hover {
+    background-color: #d0e8ff;
+}
+
+QLineEdit {
+    background-color: #ffffff;
+    color: #003366;
+    border: 1px solid #6699cc;
+    padding: 4px;
+}
+
+QLabel {
+    color: #003366;
+}

--- a/app/styles/material_dark.qss
+++ b/app/styles/material_dark.qss
@@ -1,0 +1,30 @@
+/* Material dark theme */
+QDialog {
+    background-color: #121212;
+    color: #ffffff;
+    font-family: "Roboto", sans-serif;
+    font-size: 14px;
+}
+
+QPushButton {
+    background-color: #1e1e1e;
+    color: #ffffff;
+    border: 1px solid #bb86fc;
+    border-radius: 4px;
+    padding: 6px 12px;
+}
+
+QPushButton:hover {
+    background-color: #2c2c2c;
+}
+
+QLineEdit {
+    background-color: #1e1e1e;
+    color: #ffffff;
+    border: 1px solid #bb86fc;
+    padding: 4px;
+}
+
+QLabel {
+    color: #ffffff;
+}

--- a/app/styles/material_light.qss
+++ b/app/styles/material_light.qss
@@ -1,0 +1,30 @@
+/* Material light theme */
+QDialog {
+    background-color: #ffffff;
+    color: #000000;
+    font-family: "Roboto", sans-serif;
+    font-size: 14px;
+}
+
+QPushButton {
+    background-color: #f5f5f5;
+    color: #000000;
+    border: 1px solid #6200ee;
+    border-radius: 4px;
+    padding: 6px 12px;
+}
+
+QPushButton:hover {
+    background-color: #e0e0e0;
+}
+
+QLineEdit {
+    background-color: #ffffff;
+    color: #000000;
+    border: 1px solid #6200ee;
+    padding: 4px;
+}
+
+QLabel {
+    color: #000000;
+}

--- a/app/styles/neon_purple.qss
+++ b/app/styles/neon_purple.qss
@@ -1,0 +1,30 @@
+/* Neon purple theme */
+QDialog {
+    background-color: #1b0036;
+    color: #e0b3ff;
+    font-family: "Courier New", monospace;
+    font-size: 14px;
+}
+
+QPushButton {
+    background-color: #2b0046;
+    color: #e0b3ff;
+    border: 1px solid #ff00ff;
+    border-radius: 4px;
+    padding: 6px 12px;
+}
+
+QPushButton:hover {
+    background-color: #3b0056;
+}
+
+QLineEdit {
+    background-color: #2b0046;
+    color: #e0b3ff;
+    border: 1px solid #ff00ff;
+    padding: 4px;
+}
+
+QLabel {
+    color: #e0b3ff;
+}

--- a/app/styles/ocean_blue.qss
+++ b/app/styles/ocean_blue.qss
@@ -1,0 +1,30 @@
+/* Ocean blue theme */
+QDialog {
+    background-color: #002b45;
+    color: #e0f7ff;
+    font-family: "Verdana", sans-serif;
+    font-size: 14px;
+}
+
+QPushButton {
+    background-color: #004e78;
+    color: #e0f7ff;
+    border: 1px solid #00aaff;
+    border-radius: 4px;
+    padding: 6px 12px;
+}
+
+QPushButton:hover {
+    background-color: #006699;
+}
+
+QLineEdit {
+    background-color: #004e78;
+    color: #e0f7ff;
+    border: 1px solid #00aaff;
+    padding: 4px;
+}
+
+QLabel {
+    color: #e0f7ff;
+}

--- a/app/styles/solarized_dark.qss
+++ b/app/styles/solarized_dark.qss
@@ -1,0 +1,30 @@
+/* Solarized dark theme */
+QDialog {
+    background-color: #002b36;
+    color: #839496;
+    font-family: "DejaVu Sans", sans-serif;
+    font-size: 14px;
+}
+
+QPushButton {
+    background-color: #073642;
+    color: #eee8d5;
+    border: 1px solid #586e75;
+    border-radius: 4px;
+    padding: 6px 12px;
+}
+
+QPushButton:hover {
+    background-color: #586e75;
+}
+
+QLineEdit {
+    background-color: #073642;
+    color: #eee8d5;
+    border: 1px solid #586e75;
+    padding: 4px;
+}
+
+QLabel {
+    color: #839496;
+}

--- a/app/styles/solarized_light.qss
+++ b/app/styles/solarized_light.qss
@@ -1,0 +1,30 @@
+/* Solarized light theme */
+QDialog {
+    background-color: #fdf6e3;
+    color: #657b83;
+    font-family: "DejaVu Sans", sans-serif;
+    font-size: 14px;
+}
+
+QPushButton {
+    background-color: #eee8d5;
+    color: #586e75;
+    border: 1px solid #b58900;
+    border-radius: 4px;
+    padding: 6px 12px;
+}
+
+QPushButton:hover {
+    background-color: #ddd6c4;
+}
+
+QLineEdit {
+    background-color: #ffffff;
+    color: #657b83;
+    border: 1px solid #b58900;
+    padding: 4px;
+}
+
+QLabel {
+    color: #657b83;
+}


### PR DESCRIPTION
## Summary
- add dark green, light blue, solarized, material, neon, black/white, forest and ocean themed QSS styles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9890dac44832eaa66988e3814bdea