### PR TITLE
feat: add async task registry for UI

### DIFF
--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -1,0 +1,12 @@
+"""Utility package collecting asynchronous task functions.
+
+Tasks are registered using :func:`register_task` and stored in :data:`TASKS`.
+Importing this package loads the default tasks so that they are ready to use.
+"""
+
+from .registry import TASKS, register_task  # noqa: F401
+
+# Import default tasks to populate TASKS on package import
+from . import default_tasks  # noqa: F401
+
+__all__ = ["TASKS", "register_task"]

--- a/app/tasks/default_tasks.py
+++ b/app/tasks/default_tasks.py
@@ -1,0 +1,83 @@
+"""Default task implementations and placeholders.
+
+Each task function accepts three parameters:
+    args: tuple of parameters from UI
+    progress: function to update progress bar (int 0-100)
+    text: function to send text/HTML to the UI
+
+Use @register_task("任务名称") to register a function so that the UI
+can find and execute it asynchronously.
+"""
+
+import time
+from pathlib import Path
+from .registry import register_task
+
+# Importing directly to avoid circular import with app.ui
+from core.utils.visualization import get_pe_info_html as FileInfo
+
+try:
+    import pefile
+except Exception:  # pragma: no cover - pefile may be missing during tests
+    pefile = None
+
+
+@register_task("文件信息")
+def file_info(args, progress, text):
+    """Parse PE file and report sections/imports with progress."""
+    if not args:
+        text("未提供文件路径")
+        return
+    path = Path(args[0])
+    if pefile is None:
+        text("缺少pefile库，无法解析")
+        return
+    try:
+        pe = pefile.PE(str(path))
+    except Exception as e:  # pragma: no cover - runtime errors
+        text(f"解析PE失败: {e}")
+        return
+
+    total_sections = len(pe.sections) or 1
+    for idx, section in enumerate(pe.sections, 1):
+        percent = int((idx / total_sections) * 50)
+        progress(percent)
+        text(f"解析节区 {idx}/{total_sections}: {section.Name.decode(errors='ignore')}")
+
+    imports = getattr(pe, "DIRECTORY_ENTRY_IMPORT", [])
+    total_funcs = sum(len(imp.imports) for imp in imports) or 1
+    counted = 0
+    for imp in imports:
+        for func in imp.imports:
+            counted += 1
+            percent = 50 + int((counted / total_funcs) * 50)
+            progress(percent)
+            name = func.name.decode(errors="ignore") if func.name else "None"
+            text(f"解析导入函数 {counted}/{total_funcs}: {name}")
+
+    html = FileInfo(path)
+    text(html)
+
+
+def _placeholder_factory(task_name: str):
+    @register_task(task_name)
+    def _task(args, progress, text, _name=task_name):
+        for i in range(1, 101):
+            time.sleep(0.01)
+            progress(i)
+        text(f"{_name}：占位（未实现）")
+    return _task
+
+# Register placeholders for other buttons
+for _name in [
+    "数据清洗",
+    "提取特征",
+    "特征转换",
+    "训练模型",
+    "测试模型",
+    "静态检测",
+    "获取良性",
+    "沙箱检测",
+    "安装依赖",
+]:
+    _placeholder_factory(_name)

--- a/app/tasks/registry.py
+++ b/app/tasks/registry.py
@@ -1,0 +1,24 @@
+"""Task registry for UI asynchronous functions."""
+from typing import Callable, Dict, Tuple
+
+# Type alias for task functions. The function receives:
+#  args: a tuple of parameters from the UI
+#  progress_callback: callable accepting int 0-100
+#  text_callback: callable accepting str (plain text or HTML)
+TaskFunc = Callable[[Tuple, Callable[[int], None], Callable[[str], None]], None]
+
+# Global registry mapping task names to functions.
+TASKS: Dict[str, TaskFunc] = {}
+
+def register_task(name: str):
+    """Decorator to register a task function.
+
+    Usage:
+        @register_task("任务名称")
+        def my_task(args, progress, text):
+            ...
+    """
+    def decorator(func: TaskFunc) -> TaskFunc:
+        TASKS[name] = func
+        return func
+    return decorator

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -233,8 +233,8 @@ class MachineLearningPEUI(QtWidgets.QDialog):
         self.btn_view_logs = QtWidgets.QPushButton("查看日志", self)
         self.btn_view_logs.setGeometry(1060, 695, 160, 35)
 
-        self.btn_model_select = QtWidgets.QPushButton("选择模型请下拉选项", self)
-        self.btn_model_select.setGeometry(1230, 695, 161, 35)
+        self.btn_clear_info = QtWidgets.QPushButton("清空文本展示区", self)
+        self.btn_clear_info.setGeometry(1230, 695, 161, 35)
 
         # 底部信息
         self.infoTextBrowser = QtWidgets.QTextBrowser(self)
@@ -270,7 +270,7 @@ class MachineLearningPEUI(QtWidgets.QDialog):
         # 其他按钮
         self.btn_download_report.clicked.connect(self.download_report)
         self.btn_view_logs.clicked.connect(self.view_logs)
-        self.btn_model_select.clicked.connect(self.select_model_button)
+        self.btn_clear_info.clicked.connect(self.clear_info_text)
 
     # --- 文件选择槽 ---
     def select_input_file(self):
@@ -334,7 +334,6 @@ class MachineLearningPEUI(QtWidgets.QDialog):
         """查看日志"""
         self._append_result_text("查看日志：占位（未实现）")
 
-    def select_model_button(self):
-        """选择模型按钮"""
-        model = self.modelComboBox.currentText()
-        self.infoTextBrowser.append(f"选择模型：{model}")
+    def clear_info_text(self):
+        """清空底部信息展示区"""
+        self.infoTextBrowser.clear()

--- a/app/ui/progress_dialog.py
+++ b/app/ui/progress_dialog.py
@@ -1,7 +1,8 @@
 # app/ui/progress_dialog.py
+"""Thread worker that executes registered tasks asynchronously."""
+
 from PyQt5 import QtCore
-from pathlib import Path
-import time
+from app.tasks import TASKS
 
 
 class Worker(QtCore.QThread):
@@ -18,56 +19,20 @@ class Worker(QtCore.QThread):
 
     def run(self):
         """执行任务"""
-        if self.task_name == "文件信息" and self.args:
-            self._run_file_info(Path(self.args[0]))
-        else:
-            # 模拟其他任务
-            for i in range(1, 101):
-                if self._stopped:
-                    break
-                time.sleep(0.02)
-                self.progress_signal.emit(i)
-                if i % 10 == 0:
-                    self.text_signal.emit(f"{self.task_name} 进行中: {i}% 参数: {self.args}")
-            if not self._stopped:
-                self.text_signal.emit(f"{self.task_name} 完成，参数: {self.args}")
-
-    def _run_file_info(self, file_path: Path):
-        """文件信息任务，解析节区和导入函数并更新进度"""
-        try:
-            import pefile
-            pe = pefile.PE(str(file_path))
-        except Exception as e:
-            self.text_signal.emit(f"解析PE失败: {e}")
+        task = TASKS.get(self.task_name)
+        if not task:
+            self.text_signal.emit(f"{self.task_name} 未实现")
             return
 
-        # 节区进度
-        total_sections = len(pe.sections)
-        for idx, section in enumerate(pe.sections, 1):
-            if self._stopped:
-                return
-            percent = int((idx / total_sections) * 50)  # 节区占前50%
-            self.progress_signal.emit(percent)
-            self.text_signal.emit(f"解析节区 {idx}/{total_sections}: {section.Name.decode(errors='ignore')}")
+        def progress(value: int):
+            if not self._stopped:
+                self.progress_signal.emit(value)
 
-        # 导入表进度
-        imports = getattr(pe, "DIRECTORY_ENTRY_IMPORT", [])
-        total_funcs = sum(len(imp.imports) for imp in imports) or 1
-        counted = 0
-        for imp in imports:
-            for func in imp.imports:
-                if self._stopped:
-                    return
-                counted += 1
-                percent = 50 + int((counted / total_funcs) * 50)  # 导入函数占后50%
-                self.progress_signal.emit(percent)
-                self.text_signal.emit(
-                    f"解析导入函数 {counted}/{total_funcs}: {func.name.decode(errors='ignore') if func.name else 'None'}")
+        def text(msg: str):
+            if not self._stopped:
+                self.text_signal.emit(msg)
 
-        # 完成后生成 HTML
-        from app.ui import FileInfo
-        html = FileInfo(file_path)
-        self.text_signal.emit(html)
+        task(self.args, progress, text)
 
     def stop(self):
         """停止任务"""

--- a/app/ui/resources.py
+++ b/app/ui/resources.py
@@ -36,7 +36,7 @@ UI_STRINGS = {
     "install_deps": "安装依赖",
     "download_report": "下载报告",
     "view_logs": "查看日志",
-    "select_model": "选择模型请下拉选项"
+    "select_model": "清空文本展示区"
 }
 
 # 颜色资源

--- a/scripts/pyqt5.ui
+++ b/scripts/pyqt5.ui
@@ -497,7 +497,7 @@ p, li { white-space: pre-wrap; }
     </rect>
    </property>
    <property name="text">
-    <string>选择模型请下拉选项</string>
+    <string>清空文本展示区</string>
    </property>
   </widget>
   <widget class="QPushButton" name="pushButton_5">


### PR DESCRIPTION
## Summary
- centralize background tasks with a simple decorator-based registry
- support PE file info parsing and placeholders for other actions
- execute UI tasks asynchronously via registry-driven worker
- replace the model-select button with a clear-text action

## Testing
- `python app/test_refactor.py` *(fails: libGL.so.1: cannot open shared object file: No such file or directory)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.0.3 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68bafa6e78d8832e9a116214b17c45e3