### PR TITLE
Implement standalone PE feature extraction and vectorization

### DIFF
--- a/app/tasks/default_tasks.py
+++ b/app/tasks/default_tasks.py
@@ -15,6 +15,10 @@ from .registry import register_task
 
 # Importing directly to avoid circular import with app.ui
 from core.utils.visualization import get_pe_info_html as FileInfo
+from core.feature_engineering.pe_parser import (
+    extract_features_from_dir,
+    vectorize_features,
+)
 
 try:
     import pefile
@@ -68,11 +72,9 @@ def _placeholder_factory(task_name: str):
         text(f"{_name}：占位（未实现）")
     return _task
 
-# Register placeholders for other buttons
+# Register placeholders for remaining buttons
 for _name in [
     "数据清洗",
-    "提取特征",
-    "特征转换",
     "训练模型",
     "测试模型",
     "静态检测",
@@ -81,3 +83,26 @@ for _name in [
     "安装依赖",
 ]:
     _placeholder_factory(_name)
+
+
+@register_task("提取特征")
+def task_extract_features(args, progress, text):
+    """Extract PE features for a directory of files."""
+
+    if len(args) < 2:
+        text("需要提供输入文件夹和输出路径")
+        return
+    input_dir, save_path = args[0], args[1]
+    extract_features_from_dir(input_dir, save_path, progress_callback=progress, text_callback=text)
+
+
+@register_task("特征转换")
+def task_vectorize_features(args, progress, text):
+    """Vectorise previously extracted features."""
+
+    if len(args) < 2:
+        text("需要提供特征文件和输出路径")
+        return
+    feature_path, save_path = args[0], args[1]
+    vectorize_features(feature_path, save_path, progress_callback=progress, text_callback=text)
+

--- a/core/feature_engineering/pe_parser.py
+++ b/core/feature_engineering/pe_parser.py
@@ -1,0 +1,191 @@
+"""High level feature extraction and vectorisation for PE files.
+
+This module exposes two main entry points used by the UI tasks:
+
+``extract_features_from_dir``
+    Walk a directory of PE files and extract raw (non-vectorised) features to a
+    JSON-lines file.
+
+``vectorize_features``
+    Convert the JSON-lines feature representation into fixed length numeric
+    vectors using feature hashing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Callable
+
+import numpy as np
+
+try:  # ``pefile`` may not be installed during tests
+    import pefile
+except Exception:  # pragma: no cover
+    pefile = None
+
+from .feature_utils import ByteEntropyHistogram, ByteHistogram, chunked_iterable, stable_hash
+from .semantic_features import get_string_features
+from .static_features import (
+    get_data_directories,
+    get_exports,
+    get_general_features,
+    get_imports,
+    get_section_features,
+)
+
+
+FEATURE_DIM = 2858  # total dimension of the vectorised feature space
+
+
+def extract_pe_features(pe_path: Path) -> Dict[str, Any]:
+    """Extract non-vectorised features from a single PE file."""
+
+    if pefile is None:
+        raise RuntimeError("pefile library not available")
+
+    with open(pe_path, "rb") as f:
+        data = f.read()
+
+    pe = pefile.PE(data=data)
+    general = get_general_features(pe, len(data))
+    directories = get_data_directories(pe)
+    sections = get_section_features(pe)
+    imports = get_imports(pe)
+    exports = get_exports(pe)
+    strings = get_string_features(pe_path)
+    byte_hist = ByteHistogram(str(pe_path), is_normalize=True).tolist()
+    byte_entropy_hist = ByteEntropyHistogram(str(pe_path)).tolist()
+
+    return {
+        "metadata": {"name": pe_path.name},
+        "general": general,
+        "datadirectories": directories,
+        "sections": sections,
+        "imports": imports,
+        "exports": exports,
+        "strings": strings,
+        "byte_hist": byte_hist,
+        "byte_entropy_hist": byte_entropy_hist,
+    }
+
+
+def extract_features_from_dir(
+    input_dir: str,
+    save_path: str,
+    progress_callback: Callable[[int], None] | None = None,
+    text_callback: Callable[[str], None] | None = None,
+) -> None:
+    """Extract features for all PE files in ``input_dir`` and save to JSON lines."""
+
+    progress_callback = progress_callback or (lambda v: None)
+    text_callback = text_callback or (lambda s: None)
+
+    paths = [p for p in Path(input_dir).glob("**/*") if p.is_file()]
+    total = len(paths) or 1
+
+    with open(save_path, "w", encoding="utf-8") as out:
+        for idx, path in enumerate(paths, 1):
+            try:
+                feats = extract_pe_features(path)
+                out.write(json.dumps(feats) + "\n")
+                text_callback(f"提取 {path.name} 成功")
+            except Exception as exc:  # pragma: no cover - runtime errors
+                text_callback(f"提取 {path.name} 失败: {exc}")
+            progress_callback(int(idx / total * 100))
+
+
+def _vectorize_single(feats: Dict[str, Any]) -> np.ndarray:
+    """Convert a single feature dictionary to a numeric vector."""
+
+    vec = np.zeros(FEATURE_DIM, dtype=np.float32)
+    offset = 0
+
+    # 1. general features (10)
+    general_order = [
+        "size",
+        "vsize",
+        "entry",
+        "code_size",
+        "init_data_size",
+        "uninit_data_size",
+        "image_base",
+        "section_align",
+        "file_align",
+        "num_sections",
+    ]
+    general_values = [feats["general"].get(k, 0) for k in general_order]
+    vec[offset : offset + len(general_values)] = general_values
+    offset += len(general_values)
+
+    # 2. data directories (32)
+    dd = feats.get("datadirectories", [])
+    vec[offset : offset + 32] = dd[:32]
+    offset += 32
+
+    # 3. byte histogram (256)
+    bh = feats.get("byte_hist", [])
+    vec[offset : offset + 256] = bh[:256]
+    offset += 256
+
+    # 4. byte entropy histogram (256)
+    beh = feats.get("byte_entropy_hist", [])
+    vec[offset : offset + 256] = beh[:256]
+    offset += 256
+
+    # 5. section features hashed (512 -> 256 for size + 256 for entropy)
+    for section in feats.get("sections", []):
+        name = section.get("name", "")
+        h = stable_hash(name, 256)
+        vec[offset + h] += section.get("size", 0)
+        vec[offset + 256 + h] += section.get("entropy", 0.0)
+    offset += 512
+
+    # 6. imported libraries hashed (256)
+    for lib in feats.get("imports", {}).get("libraries", []):
+        vec[offset + stable_hash(lib, 256)] += 1.0
+    offset += 256
+
+    # 7. imported functions hashed (1024)
+    for func in feats.get("imports", {}).get("functions", []):
+        vec[offset + stable_hash(func, 1024)] += 1.0
+    offset += 1024
+
+    # 8. exported functions hashed (256)
+    for func in feats.get("exports", []):
+        vec[offset + stable_hash(func, 256)] += 1.0
+    offset += 256
+
+    # 9. strings hashed (256)
+    for s in feats.get("strings", []):
+        vec[offset + stable_hash(s, 256)] += 1.0
+    # offset += 256  # final value not used further
+
+    return vec
+
+
+def vectorize_features(
+    feature_path: str,
+    save_path: str,
+    progress_callback: Callable[[int], None] | None = None,
+    text_callback: Callable[[str], None] | None = None,
+) -> None:
+    """Vectorise features stored in ``feature_path`` and save as ``.npy``."""
+
+    progress_callback = progress_callback or (lambda v: None)
+    text_callback = text_callback or (lambda s: None)
+
+    with open(feature_path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    total = len(lines) or 1
+    vectors: List[np.ndarray] = []
+    for idx, line in enumerate(lines, 1):
+        feats = json.loads(line)
+        vectors.append(_vectorize_single(feats))
+        progress_callback(int(idx / total * 100))
+
+    array = np.vstack(vectors)
+    np.save(save_path, array)
+    text_callback(f"保存向量到 {save_path}")
+

--- a/core/feature_engineering/semantic_features.py
+++ b/core/feature_engineering/semantic_features.py
@@ -1,0 +1,22 @@
+"""Extraction of semantic features such as printable strings."""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+
+def extract_ascii_strings(data: bytes, min_length: int = 5) -> List[str]:
+    """Extract ASCII strings from ``data`` with a minimum length."""
+
+    pattern = re.compile(rb"[ -~]{%d,}" % min_length)
+    return [m.decode("utf-8", errors="ignore") for m in pattern.findall(data)]
+
+
+def get_string_features(pe_path: str, min_length: int = 5) -> List[str]:
+    """Return a list of printable ASCII strings contained in the file."""
+
+    with open(pe_path, "rb") as f:
+        data = f.read()
+    return extract_ascii_strings(data, min_length)
+

--- a/core/feature_engineering/static_features.py
+++ b/core/feature_engineering/static_features.py
@@ -1,0 +1,93 @@
+"""Extraction of static structural features from PE files.
+
+All functions here operate on a ``pefile.PE`` object and return Python data
+structures (dicts or lists) without performing any vectorisation.  The goal is
+to keep the extraction logic separate from the later feature hashing step so
+that the raw information can be inspected and extended easily.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+try:  # ``pefile`` may not be installed during some tests
+    import pefile
+except Exception:  # pragma: no cover
+    pefile = None
+
+
+def get_general_features(pe: "pefile.PE", file_size: int) -> Dict[str, int]:
+    """Basic file information and values from the optional header."""
+
+    oh = pe.OPTIONAL_HEADER
+    fh = pe.FILE_HEADER
+    return {
+        "size": file_size,
+        "vsize": getattr(oh, "SizeOfImage", 0),
+        "entry": getattr(oh, "AddressOfEntryPoint", 0),
+        "code_size": getattr(oh, "SizeOfCode", 0),
+        "init_data_size": getattr(oh, "SizeOfInitializedData", 0),
+        "uninit_data_size": getattr(oh, "SizeOfUninitializedData", 0),
+        "image_base": getattr(oh, "ImageBase", 0),
+        "section_align": getattr(oh, "SectionAlignment", 0),
+        "file_align": getattr(oh, "FileAlignment", 0),
+        "num_sections": getattr(fh, "NumberOfSections", 0),
+    }
+
+
+def get_data_directories(pe: "pefile.PE") -> List[int]:
+    """Return a flattened list of VirtualAddress/Size for 16 directories."""
+
+    result: List[int] = []
+    dirs = getattr(pe, "OPTIONAL_HEADER", None)
+    for i in range(16):
+        if dirs and len(dirs.DATA_DIRECTORY) > i:
+            entry = dirs.DATA_DIRECTORY[i]
+            result.append(getattr(entry, "VirtualAddress", 0))
+            result.append(getattr(entry, "Size", 0))
+        else:
+            result.extend([0, 0])
+    return result
+
+
+def get_section_features(pe: "pefile.PE") -> List[Dict[str, float]]:
+    """Return name, raw size and entropy for each section."""
+
+    sections: List[Dict[str, float]] = []
+    for section in getattr(pe, "sections", []) or []:
+        name = section.Name.decode(errors="ignore").rstrip("\x00")
+        entropy_fn = getattr(section, "get_entropy", lambda: 0.0)
+        sections.append(
+            {
+                "name": name,
+                "size": int(getattr(section, "SizeOfRawData", 0)),
+                "entropy": float(entropy_fn()),
+            }
+        )
+    return sections
+
+
+def get_imports(pe: "pefile.PE") -> Dict[str, List[str]]:
+    """Return imported libraries and functions."""
+
+    libs: List[str] = []
+    funcs: List[str] = []
+    for entry in getattr(pe, "DIRECTORY_ENTRY_IMPORT", []) or []:
+        libs.append(entry.dll.decode(errors="ignore"))
+        for imp in entry.imports:
+            if imp.name:
+                funcs.append(imp.name.decode(errors="ignore"))
+    return {"libraries": libs, "functions": funcs}
+
+
+def get_exports(pe: "pefile.PE") -> List[str]:
+    """Return list of exported function names."""
+
+    names: List[str] = []
+    directory = getattr(pe, "DIRECTORY_ENTRY_EXPORT", None)
+    if directory and getattr(directory, "symbols", None):
+        for sym in directory.symbols:
+            if sym.name:
+                names.append(sym.name.decode(errors="ignore"))
+    return names
+


### PR DESCRIPTION
## Summary
- add utilities and hashing helpers for byte-level histograms
- implement static/semantic PE feature extraction and hashing-based vectorizer (2858 dims)
- wire feature extraction and transformation tasks into the UI with progress updates

## Testing
- `python -m py_compile core/feature_engineering/feature_utils.py core/feature_engineering/static_features.py core/feature_engineering/semantic_features.py core/feature_engineering/pe_parser.py app/tasks/default_tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_68c15bcf0b58832e977bc77e717670be