### PR TITLE
Add LightGBM training pipeline and GUI integration

### DIFF
--- a/app/tasks/default_tasks.py
+++ b/app/tasks/default_tasks.py
@@ -20,6 +20,7 @@ from core.feature_engineering import (
     extract_from_directory,
     vectorize_feature_file,
 )
+from core.modeling.trainer import LightGBMTrainer
 
 try:
     import pefile
@@ -120,10 +121,28 @@ def feature_vector_task(args, progress, text):
     text("特征向量化完成")
 
 
+@register_task("训练模型")
+def train_model_task(args, progress, text):
+    """Train a LightGBM model using EMBER-style NumPy vectors."""
+
+    if len(args) < 2:
+        text("需要提供向量化数据路径和模型保存目录")
+        return
+
+    dataset_path, output_dir = args[0], args[1]
+    trainer = LightGBMTrainer()
+
+    try:
+        trainer.train_from_path(dataset_path, output_dir, progress_callback=progress, text_callback=text)
+        text("模型训练完成")
+    except Exception as exc:  # pragma: no cover - runtime errors are surfaced in UI
+        text(f"训练失败: {exc}")
+        raise
+
+
 # Register placeholders for remaining buttons -------------------------------
 for _name in [
     "数据清洗",
-    "训练模型",
     "测试模型",
     "静态检测",
     "获取良性",

--- a/core/modeling/evaluator.py
+++ b/core/modeling/evaluator.py
@@ -1,0 +1,66 @@
+"""Evaluation helpers for LightGBM models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional
+
+import numpy as np
+from sklearn.metrics import accuracy_score, precision_recall_fscore_support, roc_auc_score
+
+
+@dataclass
+class EvaluationResult:
+    """Container holding common binary classification metrics."""
+
+    accuracy: float
+    auc: Optional[float]
+    precision: float
+    recall: float
+    f1: float
+    threshold: float = 0.5
+
+    def to_dict(self) -> Dict[str, float]:
+        return {
+            "accuracy": self.accuracy,
+            "auc": self.auc if self.auc is not None else float("nan"),
+            "precision": self.precision,
+            "recall": self.recall,
+            "f1": self.f1,
+            "threshold": self.threshold,
+        }
+
+
+def evaluate_binary_classifier(
+    y_true: Iterable[int] | np.ndarray,
+    y_scores: Iterable[float] | np.ndarray,
+    threshold: float = 0.5,
+) -> EvaluationResult:
+    """Compute accuracy, ROC-AUC and PR metrics for binary classifiers."""
+
+    y_true_arr = np.asarray(y_true)
+    scores = np.asarray(y_scores)
+    preds = (scores >= threshold).astype(int)
+
+    accuracy = float(accuracy_score(y_true_arr, preds))
+
+    try:
+        auc = float(roc_auc_score(y_true_arr, scores))
+    except ValueError:
+        auc = None
+
+    precision, recall, f1, _ = precision_recall_fscore_support(
+        y_true_arr, preds, average="binary", zero_division=0
+    )
+
+    return EvaluationResult(
+        accuracy=accuracy,
+        auc=auc,
+        precision=float(precision),
+        recall=float(recall),
+        f1=float(f1),
+        threshold=threshold,
+    )
+
+
+__all__ = ["EvaluationResult", "evaluate_binary_classifier"]

--- a/core/modeling/model_factory.py
+++ b/core/modeling/model_factory.py
@@ -1,0 +1,74 @@
+"""Model factory for LightGBM classifiers used throughout the project.
+
+The project follows the public EMBER dataset reference implementation which
+trains a gradient boosting decision tree model using LightGBM.  This module
+collects the default parameters and helper utilities so that other parts of the
+codebase (GUI tasks, trainers, evaluators) can import a single location for
+model configuration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Optional
+
+
+_DEFAULT_EMBER_PARAMS: Dict[str, Any] = {
+    "boosting_type": "gbdt",
+    "objective": "binary",
+    "metric": "auc",
+    "max_depth": -1,
+    "num_leaves": 153,
+    "learning_rate": 0.05,
+    "feature_fraction": 1.0,
+    "bagging_fraction": 0.7,
+    "bagging_freq": 1,
+    "min_data_in_leaf": 20,
+    "lambda_l1": 0.0,
+    "lambda_l2": 0.0,
+    "max_bin": 255,
+    "verbose": -1,
+}
+
+
+@dataclass
+class LightGBMConfig:
+    """Configuration container mirroring the official EMBER training setup."""
+
+    params: Dict[str, Any] = field(default_factory=lambda: dict(_DEFAULT_EMBER_PARAMS))
+    num_boost_round: int = 1000
+    early_stopping_rounds: int = 50
+    validation_fraction: float = 0.1
+    random_state: int = 2018
+
+    def merged_params(self, overrides: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+        """Return a dictionary of training parameters with overrides applied."""
+
+        merged: Dict[str, Any] = dict(self.params)
+        if overrides:
+            for key, value in overrides.items():
+                if value is None:
+                    continue
+                merged[key] = value
+        return merged
+
+
+def make_lightgbm_config(overrides: Optional[Mapping[str, Any]] = None) -> LightGBMConfig:
+    """Construct a :class:`LightGBMConfig` applying optional overrides."""
+
+    cfg = LightGBMConfig()
+    if overrides:
+        cfg.params.update({k: v for k, v in overrides.items() if k in cfg.params})
+        # Allow overriding basic training hyper-parameters as well.
+        if "num_boost_round" in overrides:
+            cfg.num_boost_round = int(overrides["num_boost_round"])
+        if "early_stopping_rounds" in overrides:
+            cfg.early_stopping_rounds = int(overrides["early_stopping_rounds"])
+        if "validation_fraction" in overrides:
+            cfg.validation_fraction = float(overrides["validation_fraction"])
+        if "random_state" in overrides:
+            cfg.random_state = int(overrides["random_state"])
+    return cfg
+
+
+__all__ = ["LightGBMConfig", "make_lightgbm_config"]

--- a/core/modeling/trainer.py
+++ b/core/modeling/trainer.py
@@ -1,0 +1,335 @@
+"""Training utilities for LightGBM models using EMBER-style features."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Mapping, Optional
+
+import lightgbm as lgb
+import numpy as np
+from sklearn.model_selection import train_test_split
+
+from .evaluator import EvaluationResult, evaluate_binary_classifier
+from .model_factory import LightGBMConfig, make_lightgbm_config
+from .uncertainty import ProbabilitySummary, summarise_probabilities
+
+ProgressCallback = Callable[[int], None]
+TextCallback = Callable[[str], None]
+
+
+@dataclass
+class TrainingDataset:
+    """Container holding train/validation/test splits."""
+
+    train_x: np.ndarray
+    train_y: np.ndarray
+    valid_x: Optional[np.ndarray] = None
+    valid_y: Optional[np.ndarray] = None
+    test_x: Optional[np.ndarray] = None
+    test_y: Optional[np.ndarray] = None
+
+    def ensure_float32(self) -> "TrainingDataset":
+        self.train_x = np.asarray(self.train_x, dtype=np.float32)
+        if self.valid_x is not None:
+            self.valid_x = np.asarray(self.valid_x, dtype=np.float32)
+        if self.test_x is not None:
+            self.test_x = np.asarray(self.test_x, dtype=np.float32)
+        self.train_y = np.asarray(self.train_y, dtype=np.float32)
+        if self.valid_y is not None:
+            self.valid_y = np.asarray(self.valid_y, dtype=np.float32)
+        if self.test_y is not None:
+            self.test_y = np.asarray(self.test_y, dtype=np.float32)
+        return self
+
+
+_KEY_ALIASES = {
+    "x_train": "train_x",
+    "train_x": "train_x",
+    "trainfeatures": "train_x",
+    "train_features": "train_x",
+    "trainfeature": "train_x",
+    "features_train": "train_x",
+    "train": "train_x",
+    "x_valid": "valid_x",
+    "valid_x": "valid_x",
+    "x_val": "valid_x",
+    "val_x": "valid_x",
+    "validation_x": "valid_x",
+    "validfeatures": "valid_x",
+    "val_features": "valid_x",
+    "valid_features": "valid_x",
+    "x_test": "test_x",
+    "test_x": "test_x",
+    "testfeatures": "test_x",
+    "test_features": "test_x",
+    "features_test": "test_x",
+    "y_train": "train_y",
+    "train_y": "train_y",
+    "trainlabels": "train_y",
+    "train_labels": "train_y",
+    "labels_train": "train_y",
+    "y_valid": "valid_y",
+    "valid_y": "valid_y",
+    "y_val": "valid_y",
+    "val_y": "valid_y",
+    "validation_y": "valid_y",
+    "valid_labels": "valid_y",
+    "val_labels": "valid_y",
+    "y_test": "test_y",
+    "test_y": "test_y",
+    "testlabels": "test_y",
+    "test_labels": "test_y",
+    "labels_test": "test_y",
+}
+
+
+def _normalise_key(name: str) -> Optional[str]:
+    clean = name.lower().replace("-", "_").replace(" ", "_")
+    clean = clean.replace(".npy", "").replace(".npz", "")
+    clean = clean.replace(".", "_")
+    return _KEY_ALIASES.get(clean)
+
+
+def _load_from_np_archive(path: Path) -> Dict[str, np.ndarray]:
+    arrays: Dict[str, np.ndarray] = {}
+    with np.load(path, allow_pickle=True) as data:
+        for key in data.files:
+            normalised = _normalise_key(key)
+            if normalised:
+                arrays[normalised] = data[key]
+    return arrays
+
+
+def _load_from_npy(path: Path) -> Dict[str, np.ndarray]:
+    data = np.load(path, allow_pickle=True)
+    arrays: Dict[str, np.ndarray] = {}
+    if isinstance(data, np.lib.npyio.NpzFile):
+        return _load_from_np_archive(path)
+    if isinstance(data, np.ndarray) and data.dtype == object:
+        try:
+            obj = data.item()
+            if isinstance(obj, Mapping):
+                for key, value in obj.items():
+                    normalised = _normalise_key(str(key))
+                    if normalised:
+                        arrays[normalised] = np.asarray(value)
+                return arrays
+        except Exception:
+            pass
+    # Otherwise treat it as a single feature matrix (train_x)
+    arrays["train_x"] = np.asarray(data)
+    return arrays
+
+
+def _load_from_directory(path: Path) -> Dict[str, np.ndarray]:
+    arrays: Dict[str, np.ndarray] = {}
+    for file in path.iterdir():
+        if not file.is_file():
+            continue
+        if file.suffix.lower() == ".npz":
+            arrays.update(_load_from_np_archive(file))
+        elif file.suffix.lower() == ".npy":
+            arrays.update(_load_from_npy(file))
+    return arrays
+
+
+def load_numpy_dataset(path: str | Path, text_callback: Optional[TextCallback] = None) -> TrainingDataset:
+    """Load train/valid/test arrays from a directory or numpy file."""
+
+    callback = text_callback or (lambda *_: None)
+    location = Path(path)
+    if not location.exists():
+        raise FileNotFoundError(f"找不到数据文件: {path}")
+
+    callback(f"加载数据: {location}")
+
+    if location.is_dir():
+        arrays = _load_from_directory(location)
+    else:
+        if location.suffix.lower() == ".npz":
+            arrays = _load_from_np_archive(location)
+        elif location.suffix.lower() == ".npy":
+            arrays = _load_from_npy(location)
+        else:
+            raise ValueError("仅支持 .npy 或 .npz 文件")
+
+    train_x = arrays.get("train_x")
+    train_y = arrays.get("train_y")
+
+    if train_x is None or train_y is None:
+        raise ValueError("数据中缺少 train_x 或 train_y。请提供包含特征和标签的 .npy/.npz 文件。")
+
+    dataset = TrainingDataset(
+        train_x=train_x,
+        train_y=train_y,
+        valid_x=arrays.get("valid_x"),
+        valid_y=arrays.get("valid_y"),
+        test_x=arrays.get("test_x"),
+        test_y=arrays.get("test_y"),
+    )
+    return dataset.ensure_float32()
+
+
+class LightGBMTrainer:
+    """High level helper that mirrors the official EMBER training recipe."""
+
+    def __init__(self, config: Optional[LightGBMConfig] = None):
+        self.config = config or LightGBMConfig()
+
+    def _split_validation(
+        self,
+        dataset: TrainingDataset,
+        config: LightGBMConfig,
+        random_state: int,
+        text_callback: TextCallback,
+    ) -> TrainingDataset:
+        if dataset.valid_x is not None and dataset.valid_y is not None:
+            return dataset
+        if config.validation_fraction <= 0:
+            return dataset
+        text_callback(f"创建 {config.validation_fraction:.0%} 验证集用于早停")
+        train_x, valid_x, train_y, valid_y = train_test_split(
+            dataset.train_x,
+            dataset.train_y,
+            test_size=config.validation_fraction,
+            random_state=random_state,
+            stratify=dataset.train_y if len(np.unique(dataset.train_y)) > 1 else None,
+        )
+        dataset.train_x = train_x
+        dataset.train_y = train_y
+        dataset.valid_x = valid_x
+        dataset.valid_y = valid_y
+        return dataset
+
+    def train_from_path(
+        self,
+        dataset_path: str | Path,
+        output_dir: str | Path,
+        progress_callback: Optional[ProgressCallback] = None,
+        text_callback: Optional[TextCallback] = None,
+        overrides: Optional[Mapping[str, float]] = None,
+    ) -> Path:
+        dataset = load_numpy_dataset(dataset_path, text_callback)
+        return self.train(dataset, output_dir, progress_callback, text_callback, overrides=overrides)
+
+    def train(
+        self,
+        dataset: TrainingDataset,
+        output_dir: str | Path,
+        progress_callback: Optional[ProgressCallback] = None,
+        text_callback: Optional[TextCallback] = None,
+        overrides: Optional[Mapping[str, float]] = None,
+    ) -> Path:
+        progress = progress_callback or (lambda *_: None)
+        text = text_callback or (lambda *_: None)
+
+        config = make_lightgbm_config(overrides) if overrides else self.config
+        progress(5)
+        text("初始化 LightGBM 训练器")
+
+        dataset = self._split_validation(dataset, config, config.random_state, text).ensure_float32()
+        progress(15)
+        text("构建 LightGBM 数据集")
+
+        train_data = lgb.Dataset(dataset.train_x, label=dataset.train_y)
+        valid_sets = [train_data]
+        valid_names = ["train"]
+        if dataset.valid_x is not None and dataset.valid_y is not None:
+            valid_data = lgb.Dataset(dataset.valid_x, label=dataset.valid_y, reference=train_data)
+            valid_sets.append(valid_data)
+            valid_names.append("valid")
+
+        num_rounds = config.num_boost_round
+        train_start = time.time()
+
+        def _progress_callback(total_rounds: int, start: int, end: int) -> Callable[[lgb.callback.CallbackEnv], None]:
+            span = max(end - start, 1)
+
+            def _callback(env: lgb.callback.CallbackEnv) -> None:
+                iteration = env.iteration
+                frac = min(iteration / float(total_rounds), 1.0)
+                progress_value = start + int(frac * span)
+                progress(min(progress_value, end))
+                if env.evaluation_result_list and (iteration % 50 == 0 or iteration == total_rounds):
+                    parts = [
+                        f"{name}-{metric}:{value:.5f}"
+                        for name, metric, value, _ in env.evaluation_result_list
+                    ]
+                    text(f"迭代 {iteration}: {' | '.join(parts)}")
+
+            return _callback
+
+        text("开始训练 LightGBM 模型（参考 EMBER 官方配置）")
+        booster = lgb.train(
+            config.params,
+            train_data,
+            num_boost_round=num_rounds,
+            valid_sets=valid_sets,
+            valid_names=valid_names,
+            callbacks=[
+                _progress_callback(num_rounds, 15, 85),
+                lgb.early_stopping(config.early_stopping_rounds, verbose=False),
+                lgb.log_evaluation(period=50),
+            ],
+        )
+
+        best_iteration = booster.best_iteration or booster.current_iteration()
+        train_duration = time.time() - train_start
+        text(f"训练完成，最佳迭代次数: {best_iteration}，耗时 {train_duration:.1f} 秒")
+        progress(90)
+
+        metrics: Dict[str, EvaluationResult] = {}
+        summaries: Dict[str, ProbabilitySummary] = {}
+
+        def _evaluate(split_name: str, features: Optional[np.ndarray], labels: Optional[np.ndarray]) -> None:
+            if features is None or labels is None:
+                return
+            scores = booster.predict(features, num_iteration=best_iteration)
+            metrics[split_name] = evaluate_binary_classifier(labels, scores)
+            summaries[split_name] = summarise_probabilities(scores)
+            text(
+                f"{split_name} 集: 准确率 {metrics[split_name].accuracy:.4f}, "
+                f"AUC {metrics[split_name].auc if metrics[split_name].auc is not None else float('nan'):.4f}"
+            )
+
+        _evaluate("train", dataset.train_x, dataset.train_y)
+        _evaluate("valid", dataset.valid_x, dataset.valid_y)
+        _evaluate("test", dataset.test_x, dataset.test_y)
+
+        progress(95)
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        model_file = output_path / "lightgbm_model.txt"
+        booster.save_model(str(model_file))
+
+        feature_importance = booster.feature_importance(importance_type="gain")
+        report = {
+            "config": {
+                "params": config.params,
+                "num_boost_round": num_rounds,
+                "early_stopping_rounds": config.early_stopping_rounds,
+                "validation_fraction": config.validation_fraction,
+                "random_state": config.random_state,
+            },
+            "best_iteration": best_iteration,
+            "train_duration_sec": train_duration,
+            "metrics": {split: result.to_dict() for split, result in metrics.items()},
+            "probability_summary": {split: summary.to_dict() for split, summary in summaries.items()},
+            "feature_importance": feature_importance.tolist(),
+        }
+
+        report_file = output_path / "training_report.json"
+        with report_file.open("w", encoding="utf-8") as fh:
+            json.dump(report, fh, indent=2, ensure_ascii=False)
+
+        text(f"模型已保存至 {model_file}")
+        text(f"训练报告已保存至 {report_file}")
+        progress(100)
+        return model_file
+
+
+__all__ = ["TrainingDataset", "LightGBMTrainer", "load_numpy_dataset"]

--- a/core/modeling/uncertainty.py
+++ b/core/modeling/uncertainty.py
@@ -1,0 +1,44 @@
+"""Utility helpers to summarise prediction uncertainty."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+
+@dataclass
+class ProbabilitySummary:
+    """Summary statistics for a list of probability predictions."""
+
+    mean: float
+    std: float
+    percentile_05: float
+    percentile_95: float
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "mean": self.mean,
+            "std": self.std,
+            "percentile_05": self.percentile_05,
+            "percentile_95": self.percentile_95,
+        }
+
+
+def summarise_probabilities(probs: Iterable[float]) -> ProbabilitySummary:
+    """Return simple uncertainty statistics for probability predictions."""
+
+    arr = np.asarray(list(probs), dtype=float)
+    if arr.size == 0:
+        return ProbabilitySummary(mean=float("nan"), std=float("nan"), percentile_05=float("nan"), percentile_95=float("nan"))
+
+    return ProbabilitySummary(
+        mean=float(arr.mean()),
+        std=float(arr.std(ddof=0)),
+        percentile_05=float(np.percentile(arr, 5)),
+        percentile_95=float(np.percentile(arr, 95)),
+    )
+
+
+__all__ = ["ProbabilitySummary", "summarise_probabilities"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ PyQt5~=5.15.9
 lief~=0.16.6
 numpy~=1.24.3
 scikit-learn~=1.7.1
+lightgbm~=4.5.0


### PR DESCRIPTION
## Summary
- implement LightGBM model factory, trainer, evaluator, and uncertainty helpers following EMBER defaults
- hook the GUI "训练模型" task to run LightGBM training on EMBER-style NumPy datasets and emit reports
- add the lightgbm dependency required for model training

## Testing
- python -m compileall core/modeling app/tasks/default_tasks.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a7a5b658832e997c5bffeba82545