### PR TITLE
Add prediction script for official EMBER model

### DIFF
--- a/scripts/predict_ember_official.py
+++ b/scripts/predict_ember_official.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""使用 EMBER 官方模型预测单个或多个 PE 文件是否为恶意样本的脚本。
+
+该脚本读取 ``train_ember_official.py`` 生成的 LightGBM ``model.txt``，
+通过 :class:`ember.PEFeatureExtractor` 从 PE 文件中提取特征，再调用模型
+输出恶意概率与标签判断结果，完全遵循 EMBER 官方 API。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Iterable, List
+
+import ember
+import lightgbm as lgb
+import numpy as np
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="predict_ember_official",
+        description="加载 EMBER 模型并对给定 PE 文件进行预测",
+    )
+    parser.add_argument(
+        "model",
+        metavar="MODEL",
+        help="使用 train_ember_official.py 训练得到的 model.txt 路径",
+    )
+    parser.add_argument(
+        "files",
+        nargs="+",
+        metavar="PE",
+        help="待预测的一个或多个 PE 文件路径",
+    )
+    parser.add_argument(
+        "-v",
+        "--featureversion",
+        type=int,
+        default=2,
+        help="EMBER 特征版本（默认 2，与官方一致）",
+    )
+    parser.add_argument(
+        "-t",
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="判定为恶意样本的概率阈值，默认 0.5",
+    )
+    parser.add_argument(
+        "-j",
+        "--json",
+        action="store_true",
+        help="以 JSON 格式输出预测结果，方便脚本化处理",
+    )
+    return parser.parse_args()
+
+
+def load_model(model_path: str | os.PathLike[str]) -> lgb.Booster:
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(f"模型文件不存在: {model_path}")
+    return lgb.Booster(model_file=str(model_path))
+
+
+def extract_features(
+    extractor: ember.PEFeatureExtractor, path: str | os.PathLike[str]
+) -> np.ndarray:
+    with open(path, "rb") as f:
+        bytez = f.read()
+    return extractor.feature_vector(bytez)
+
+
+def batch_predict(
+    model: lgb.Booster,
+    extractor: ember.PEFeatureExtractor,
+    files: Iterable[str],
+) -> List[tuple[str, float]]:
+    features: List[np.ndarray] = []
+    valid_paths: List[str] = []
+    for file_path in files:
+        try:
+            features.append(extract_features(extractor, file_path))
+            valid_paths.append(file_path)
+        except Exception as exc:  # noqa: BLE001 - 保留原始异常信息便于排查
+            print(f"提取特征失败，跳过 {file_path}: {exc}")
+    if not features:
+        return []
+    feature_matrix = np.vstack(features)
+    scores = model.predict(feature_matrix)
+    # LightGBM 返回 shape=(n,) 的 ndarray
+    return list(zip(valid_paths, scores.tolist()))
+
+
+def main() -> None:
+    args = parse_args()
+
+    model = load_model(args.model)
+    extractor = ember.PEFeatureExtractor(feature_version=args.featureversion)
+
+    predictions = batch_predict(model, extractor, args.files)
+    if not predictions:
+        raise SystemExit("未获得任何有效预测结果，请检查输入文件。")
+
+    threshold = args.threshold
+    results = []
+    for path, score in predictions:
+        label = "malicious" if score >= threshold else "benign"
+        results.append({
+            "file": str(Path(path)),
+            "score": float(score),
+            "label": label,
+            "threshold": threshold,
+        })
+
+    if args.json:
+        print(json.dumps(results, indent=2, ensure_ascii=False))
+    else:
+        for item in results:
+            print(
+                f"{item['file']}: score={item['score']:.6f}, "
+                f"threshold={threshold:.2f} -> {item['label']}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_ember_official.py
+++ b/scripts/train_ember_official.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""官方 EMBER 训练流程脚本。
+
+该脚本紧跟 EMBER 官方仓库提供的 ``init_ember.py`` / ``ember.train_model`` 实现，
+用于在包含原始特征 JSON 的目录中执行以下操作：
+
+1. 如果尚未生成 ``X_train.dat``、``y_train.dat`` 等向量化特征文件，则调用
+   :func:`ember.create_vectorized_features` 完成转换；
+2. 按需生成 metadata CSV；
+3. 使用官方推荐的 LightGBM 超参数训练模型，并保存 ``model.txt``。
+
+运行示例::
+
+    python scripts/train_ember_official.py -t -m /path/to/ember2018
+
+脚本会将训练得到的模型保存到 ``model.txt``（或 ``--output`` 指定的路径），
+从而与 EMBER 官方流程保持一致。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Dict
+
+import ember
+
+# EMBER 官方脚本中使用的默认 LightGBM 参数
+DEFAULT_PARAMS: Dict[str, object] = {
+    "boosting": "gbdt",
+    "objective": "binary",
+    "num_iterations": 1000,
+    "learning_rate": 0.05,
+    "num_leaves": 2048,
+    "max_depth": 15,
+    "min_data_in_leaf": 50,
+    "feature_fraction": 0.5,
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="train_ember_official",
+        description="使用 EMBER 官方方法训练 LightGBM 模型",
+    )
+    parser.add_argument(
+        "datadir",
+        metavar="DATADIR",
+        help="包含 EMBER 原始 JSON 特征的目录",
+    )
+    parser.add_argument(
+        "-v",
+        "--featureversion",
+        type=int,
+        default=2,
+        help="EMBER 特征版本（默认为 2）",
+    )
+    parser.add_argument(
+        "-m",
+        "--metadata",
+        action="store_true",
+        help="生成 metadata CSV（与官方脚本一致）",
+    )
+    parser.add_argument(
+        "-t",
+        "--train",
+        action="store_true",
+        help="执行模型训练流程（与官方脚本一致）",
+    )
+    parser.add_argument(
+        "--optimize",
+        action="store_true",
+        help="调用 ember.optimize_model 进行网格搜索，与官方脚本一致",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="model.txt",
+        help="模型输出文件名，默认写入 DATADIR/model.txt",
+    )
+    return parser.parse_args()
+
+
+def ensure_vectorized_features(data_dir: str, feature_version: int) -> None:
+    """确保向量化特征文件存在，若不存在则调用官方函数生成。"""
+
+    x_train_path = os.path.join(data_dir, "X_train.dat")
+    y_train_path = os.path.join(data_dir, "y_train.dat")
+    if os.path.exists(x_train_path) and os.path.exists(y_train_path):
+        return
+
+    print("未检测到向量化特征，正在调用 ember.create_vectorized_features()...")
+    ember.create_vectorized_features(data_dir, feature_version)
+
+
+def main() -> None:
+    args = parse_args()
+
+    if not os.path.isdir(args.datadir):
+        raise SystemExit(f"{args.datadir} 不是有效的目录")
+
+    ensure_vectorized_features(args.datadir, args.featureversion)
+
+    if args.metadata:
+        print("生成 metadata CSV...")
+        ember.create_metadata(args.datadir)
+
+    if args.train:
+        params = DEFAULT_PARAMS.copy()
+        if args.optimize:
+            print("执行参数网格搜索...")
+            params = ember.optimize_model(args.datadir)
+            print("最佳参数如下：")
+            print(json.dumps(params, indent=2, ensure_ascii=False))
+
+        print("按照 EMBER 官方方式训练 LightGBM 模型...")
+        model = ember.train_model(args.datadir, params, args.featureversion)
+
+        output_path = args.output
+        if not os.path.isabs(output_path):
+            output_path = os.path.join(args.datadir, output_path)
+
+        model.save_model(output_path)
+        print(f"模型已保存至: {output_path}")
+    else:
+        print("未指定 --train，脚本仅完成特征准备任务。")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a CLI helper to load the official EMBER LightGBM model and score PE files
- support batch predictions, configurable thresholding, and optional JSON output for automation

## Testing
- python -m compileall scripts/predict_ember_official.py

------
https://chatgpt.com/codex/tasks/task_e_68d6aedca9d0832e809c9d56ea34dc5c